### PR TITLE
[PDA-8/fix] 회의실 검색 필터로 설정한 정보 헤더에 저장 및 화면 리로드 시 반영되도록 수정

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -39,7 +39,6 @@ PODS:
   - fluttertoast (0.0.2):
     - Flutter
     - Toast
-  - Toast (4.0.0)
   - GoogleDataTransport (9.2.5):
     - GoogleUtilities/Environment (~> 7.7)
     - nanopb (< 2.30910.0, >= 2.30908.0)
@@ -67,6 +66,7 @@ PODS:
   - nanopb/decode (2.30909.1)
   - nanopb/encode (2.30909.1)
   - PromisesObjC (2.3.1)
+  - Toast (4.0.0)
 
 DEPENDENCIES:
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
@@ -75,10 +75,6 @@ DEPENDENCIES:
   - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
   - fluttertoast (from `.symlinks/plugins/fluttertoast/ios`)
-
-SPEC REPOS:
-  trunk:
-    - Toast
 
 SPEC REPOS:
   trunk:
@@ -91,6 +87,7 @@ SPEC REPOS:
     - GoogleUtilities
     - nanopb
     - PromisesObjC
+    - Toast
 
 EXTERNAL SOURCES:
   firebase_core:
@@ -117,12 +114,12 @@ SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   flutter_local_notifications: 0c0b1ae97e741e1521e4c1629a459d04b9aec743
   flutter_secure_storage: 23fc622d89d073675f2eaa109381aefbcf5a49be
-  fluttertoast: fafc4fa4d01a6a9e4f772ecd190ffa525e9e2d9c
-  Toast: 91b396c56ee72a5790816f40d3a94dd357abc196
+  fluttertoast: 31b00dabfa7fb7bacd9e7dbee580d7a2ff4bf265
   GoogleDataTransport: 54dee9d48d14580407f8f5fbf2f496e92437a2f2
   GoogleUtilities: 202e7a9f5128accd11160fb9c19612de1911aa19
   nanopb: d4d75c12cd1316f4a64e3c6963f879ecd4b5e0d5
   PromisesObjC: c50d2056b5253dadbd6c2bea79b0674bd5a52fa4
+  Toast: 91b396c56ee72a5790816f40d3a94dd357abc196
 
 PODFILE CHECKSUM: 70d9d25280d0dd177a5f637cdb0f0b0b12c6a189
 

--- a/lib/Presenter/booking/booking_service.dart
+++ b/lib/Presenter/booking/booking_service.dart
@@ -8,9 +8,16 @@ class BookingService {
   final carListURL = '/cars';
   final resourceListURL = '/resources';
 
+  DateTime? selectedDate;
+  DateTime? startTime;
+  DateTime? endTime;
+
   String keyword = '';
-  String startDate = '';
-  String endDate = '';
+  String selectedDateStr = '';
+  String startTimeStr = '';
+  String endTimeStr = '';
+
+
 
   /// Singleton Pattern
   static final BookingService _bookingService = BookingService._();
@@ -20,42 +27,39 @@ class BookingService {
   }
 
   Future<dynamic> getOfficeListData() async {
-    setDate();
     final response = await APIManager().request(
         RequestType.get,
         officeListURL,
         null,
         (keyword.isEmpty)
             ? null
-            : {"facilityName" : keyword, "startDate" : startDate, "endDate" : endDate},
+            : {"facilityName" : keyword, "startDate" : '$selectedDateStr $startTimeStr', "endDate" : '$selectedDateStr $endTimeStr'},
         null
     );
     return response;
   }
 
   Future<dynamic> getCarListData() async {
-    setDate();
     final response = await APIManager().request(
         RequestType.get,
         carListURL,
         null,
         (keyword.isEmpty)
             ? null
-            : {"carName" : keyword, "startDate" : startDate, "endDate" : endDate},
+            : {"carName" : keyword,  "startDate" : '$selectedDateStr $startTimeStr', "endDate" : '$selectedDateStr $endTimeStr'},
         null
     );
     return response;
   }
 
   Future<dynamic> getResourceListData() async {
-    setDate();
     final response = await APIManager().request(
       RequestType.get,
       resourceListURL,
       null,
       (keyword.isEmpty)
           ? null
-          : {"resourceName" : keyword, "startDate" : startDate, "endDate" : endDate},
+          : {"resourceName" : keyword, "startDate" : '$selectedDateStr $startTimeStr', "endDate" : '$selectedDateStr $endTimeStr'},
       null
     );
     return response;
@@ -65,8 +69,20 @@ class BookingService {
   void setKeyword(String input) { keyword = input; }
   String getKeyword() { return keyword; }
 
-  void setDate() {
-    startDate = DateFormat('yyyy-MM-dd hh:mm').format(DateTime.now());
-    endDate = DateFormat('yyyy-MM-dd hh:mm').format(DateTime.now().add(const Duration(hours: 1)));
+  void setDate(DateTime date) {
+    selectedDate = date;
+    selectedDateStr = DateFormat('yyyy-MM-dd').format(selectedDate!);
+  }
+  void setStartTime(DateTime time) {
+    startTime = time;
+    startTimeStr = DateFormat('HH:mm').format(startTime!);
+  }
+  void setEndTime(DateTime time) {
+    endTime = time;
+    endTimeStr = DateFormat('HH:mm').format(endTime!);
+  }
+
+  bool isFilterInfoEmpty() {
+    return (selectedDateStr.isEmpty || startTimeStr.isEmpty || endTimeStr.isEmpty);
   }
 }

--- a/lib/View/booking/component/custom_search_bar.dart
+++ b/lib/View/booking/component/custom_search_bar.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:fluttertoast/fluttertoast.dart';
 import 'package:frontend/View/booking/screen/office_filter_screen.dart';
 import 'package:frontend/Presenter/booking/booking_service.dart';
 import 'package:frontend/View/colors.dart';
@@ -92,6 +93,10 @@ class _CustomSearchBarState extends State<CustomSearchBar> {
   }
 
   void didChangedSearchBar() {
+    if (BookingService().isFilterInfoEmpty()) {
+      Fluttertoast.showToast(msg: '사용 일자 및 시간을 선택해주세요!', gravity: ToastGravity.CENTER);
+      return;
+    }
     BookingScreenState? parent = context.findAncestorStateOfType<BookingScreenState>();
     parent!.searchItems((controller.value.text.isEmpty) ? '' : controller.value.text);
   }

--- a/lib/View/booking/screen/office_filter_screen.dart
+++ b/lib/View/booking/screen/office_filter_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:fluttertoast/fluttertoast.dart';
+import 'package:frontend/Presenter/booking/booking_service.dart';
 import 'package:frontend/View/colors.dart';
 import 'package:frontend/View/common/component/purple_bottom_button.dart';
 import 'package:frontend/View/common/component/sub_app_bar.dart';
@@ -32,6 +33,27 @@ class _OfficeFilterScreenState extends State<OfficeFilterScreen> {
 
   String startTimeHintText = startHintStr;
   String endTimeHintText = endHintStr;
+
+  @override
+  void initState() {
+    super.initState();
+
+    if (BookingService().selectedDate != null) {
+      selectedDay = BookingService().selectedDate;
+      focusedDay = selectedDay!;
+    }
+
+    if (BookingService().startTime != null) {
+      startTime = BookingService().startTime;
+      startTimeHintText = DateFormat('HH:mm').format(startTime!);
+    }
+
+    if (BookingService().endTime != null) {
+      endTime = BookingService().endTime;
+      endTimeHintText = DateFormat('HH:mm').format(endTime!);
+    }
+
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -194,6 +216,10 @@ class _OfficeFilterScreenState extends State<OfficeFilterScreen> {
       Fluttertoast.showToast(msg: '날짜와 시작, 종료 시간을 모두 선택해주세요!', gravity: ToastGravity.BOTTOM);
     } else {
       if(endTime!.isAfter(startTime!) && !(endTime!.isAtSameMomentAs(startTime!))) {
+        BookingService().setDate(selectedDay!);
+        BookingService().setStartTime(startTime!);
+        BookingService().setEndTime(endTime!);
+
         Navigator.of(context).pop();
       } else {
         Fluttertoast.showToast(msg: '종료 시간은 시작 시간보다 이후이어야 합니다.');


### PR DESCRIPTION
## ✈️ 지라 티켓
- [PDA-8](https://pladi-alm.atlassian.net/browse/PDA-8) 

<br>

## 👾 작업 내용
- 회의실 목록 중 필터 정보 없이 검색어 입력하는 경우 '날짜 및 시간을 지정'하도록 토스트 메시지 표시
- 필터 화면을 통해 날짜 및 시간 입력 후 '적용'을 탭한 경우 해당 정보가 헤더에 적용되고, 이후 필터 화면 리로드할 경우에도 반영되어있도록 수정

<br>

## 📸 스크린샷

<br>

## 🎸 기타 사항
- 


[PDA-8]: https://pladi-alm.atlassian.net/browse/PDA-8?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ