### PR TITLE
[PDA-19/feat] 이메일 인증, 비밀번호 재설정 UI 및 API 연결

### DIFF
--- a/lib/Model/model/login/email_code_request.dart
+++ b/lib/Model/model/login/email_code_request.dart
@@ -1,0 +1,20 @@
+class EmailCodeRequest {
+  String email;
+  String code;
+
+  EmailCodeRequest({
+    required this.email,
+    required this.code,
+  });
+
+  factory EmailCodeRequest.fromJson(Map<String, dynamic> json) =>
+      EmailCodeRequest(
+        email: json["email"],
+        code: json["code"],
+      );
+
+  Map<String, dynamic> toJson() => {
+        "email": email,
+        "code": code,
+      };
+}

--- a/lib/Model/model/login/email_request.dart
+++ b/lib/Model/model/login/email_request.dart
@@ -1,0 +1,15 @@
+class EmailRequest {
+  String email;
+
+  EmailRequest({
+    required this.email,
+  });
+
+  factory EmailRequest.fromJson(Map<String, dynamic> json) => EmailRequest(
+        email: json["email"],
+      );
+
+  Map<String, dynamic> toJson() => {
+        "email": email,
+      };
+}

--- a/lib/Presenter/login/login_service.dart
+++ b/lib/Presenter/login/login_service.dart
@@ -11,6 +11,7 @@ class LoginService {
   final loginURL = '/users/login';
   final emailUrl = '/users/email';
   final emailCodeUrl = '/users/email-code';
+  final passwordUrl = '/users/password';
 
   static final LoginService _loginService = LoginService._();
   LoginService._();
@@ -71,6 +72,28 @@ class LoginService {
     try {
       final response = await APIManager()
           .request(RequestType.post, emailCodeUrl, null, null, body);
+
+      if (response != null) {
+        return true;
+      } else {
+        return false;
+      }
+    } on DioError catch (e) {
+      final response = e.response;
+      if (response != null) {
+        final error =
+            GeneralModel.fromJson(response.data as Map<String, dynamic>);
+        return error.message;
+      }
+    }
+  }
+
+  Future<dynamic> changePassword(String email, String password) async {
+    final body = LoginRequest(email: email, password: password).toJson();
+
+    try {
+      final response = await APIManager()
+          .request(RequestType.patch, passwordUrl, null, null, body);
 
       if (response != null) {
         return true;

--- a/lib/Presenter/login/login_service.dart
+++ b/lib/Presenter/login/login_service.dart
@@ -1,4 +1,6 @@
 import 'package:dio/dio.dart';
+import 'package:frontend/Model/model/login/email_code_request.dart';
+import 'package:frontend/Model/model/login/email_request.dart';
 import 'package:frontend/Model/model/login/login_request.dart';
 import 'package:frontend/Model/model/login/login_response.dart';
 
@@ -7,6 +9,8 @@ import '../../Model/network/api_manager.dart';
 
 class LoginService {
   final loginURL = '/users/login';
+  final emailUrl = '/users/email';
+  final emailCodeUrl = '/users/email-code';
 
   static final LoginService _loginService = LoginService._();
   LoginService._();
@@ -23,7 +27,52 @@ class LoginService {
 
       if (response != null) {
         final data = LoginResponseModel.fromJson(response);
-        APIManager().writeToken(data.data.accessToken, data.data.refreshToken, data.data.role);
+        APIManager().writeToken(
+            data.data.accessToken, data.data.refreshToken, data.data.role);
+        return true;
+      } else {
+        return false;
+      }
+    } on DioError catch (e) {
+      final response = e.response;
+      if (response != null) {
+        final error =
+            GeneralModel.fromJson(response.data as Map<String, dynamic>);
+        return error.message;
+      }
+    }
+  }
+
+  Future<dynamic> requestEmail(String email) async {
+    final body = EmailRequest(email: email).toJson();
+
+    try {
+      final response = await APIManager()
+          .request(RequestType.post, emailUrl, null, null, body);
+
+      if (response != null) {
+        return true;
+      } else {
+        return false;
+      }
+    } on DioError catch (e) {
+      final response = e.response;
+      if (response != null) {
+        final error =
+            GeneralModel.fromJson(response.data as Map<String, dynamic>);
+        return error.message;
+      }
+    }
+  }
+
+  Future<dynamic> requestEmailCode(String email, String code) async {
+    final body = EmailCodeRequest(email: email, code: code).toJson();
+
+    try {
+      final response = await APIManager()
+          .request(RequestType.post, emailCodeUrl, null, null, body);
+
+      if (response != null) {
         return true;
       } else {
         return false;

--- a/lib/View/login/screen/email_send_screen.dart
+++ b/lib/View/login/screen/email_send_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:frontend/Presenter/login/login_service.dart';
 import 'package:frontend/View/common/component/purple_bottom_button.dart';
 import 'package:frontend/View/common/component/sub_app_bar.dart';
+import 'package:frontend/View/login/screen/password_screen.dart';
 
 class EmailSendScreen extends StatefulWidget {
   const EmailSendScreen({Key? key}) : super(key: key);
@@ -17,9 +18,17 @@ class _EmailSendScreen extends State<EmailSendScreen> {
   TextEditingController emailController = TextEditingController();
   TextEditingController codeController = TextEditingController();
 
+  bool emailEdit = false;
+
   @override
   void initState() {
     super.initState();
+  }
+
+  @override
+  void setState(VoidCallback fn) {
+    emailEdit = true;
+    super.setState(fn);
   }
 
   @override
@@ -80,6 +89,7 @@ class _EmailSendScreen extends State<EmailSendScreen> {
                     maxLines: 1,
                     focusNode: emailFocusNode,
                     obscureText: false,
+                    readOnly: emailEdit,
                     controller: emailController,
                     decoration: const InputDecoration(
                         focusedBorder: UnderlineInputBorder(
@@ -188,7 +198,9 @@ class _EmailSendScreen extends State<EmailSendScreen> {
     var email = emailController.text;
     Future<dynamic> result = LoginService().requestEmail(email);
     result.then((value) => {
-          if (value == false)
+          if (value == true)
+            {setState(() {})}
+          else if (value == false)
             {showAlert("알 수 없는 오류가 발생했습니다. 다시 시도해주세요.")}
           else
             {showAlert(value)}
@@ -201,7 +213,10 @@ class _EmailSendScreen extends State<EmailSendScreen> {
     Future<dynamic> result = LoginService().requestEmailCode(email, code);
     result.then((value) => {
           if (value == true)
-            {showAlert("성공")}
+            {
+              Navigator.of(context).push(MaterialPageRoute(
+                  builder: (_) => PasswordScreen(email: email)))
+            }
           else if (value == false)
             {showAlert("알 수 없는 오류가 발생했습니다. 다시 시도해주세요.")}
           else

--- a/lib/View/login/screen/email_send_screen.dart
+++ b/lib/View/login/screen/email_send_screen.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:frontend/View/common/component/purple_bottom_button.dart';
 import 'package:frontend/View/common/component/sub_app_bar.dart';
 
 class EmailSendScreen extends StatefulWidget {
-  const EmailSendScreen({super.key});
+  const EmailSendScreen({Key? key}) : super(key: key);
 
   @override
   State<StatefulWidget> createState() => _EmailSendScreen();
@@ -10,54 +11,139 @@ class EmailSendScreen extends StatefulWidget {
 
 class _EmailSendScreen extends State<EmailSendScreen> {
   FocusNode emailFocusNode = FocusNode();
-  FocusNode pwFocusNode = FocusNode();
+  FocusNode codeFocusNode = FocusNode();
 
   TextEditingController emailController = TextEditingController();
   TextEditingController codeController = TextEditingController();
 
   @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    emailFocusNode.dispose();
+    codeFocusNode.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return Scaffold(
-        appBar: const SubAppBar(titleText: "비밀번호 재설정"), body: renderBody());
+    return GestureDetector(
+        onTap: () {
+          emailFocusNode.unfocus();
+          codeFocusNode.unfocus();
+        },
+        child: Scaffold(
+          resizeToAvoidBottomInset: false,
+          appBar: const SubAppBar(titleText: "비밀번호 재설정"),
+          body: renderBody(),
+          backgroundColor: Colors.white,
+          bottomNavigationBar: PurpleBottomButton(
+            title: "다음",
+            onPressed: moveChangePw,
+          ),
+        ));
   }
 
   Widget renderBody() {
-    return Column(
-      children: [
-        const Text("이메일"),
-        Row(
-          children: [
-            TextField(
+    return Container(
+      width: double.infinity,
+      height: double.infinity,
+      margin: const EdgeInsets.only(top: 70, left: 21, right: 19),
+      child: Column(
+        children: [
+          const SizedBox(
+            width: double.infinity,
+            height: 20,
+            child: Text("이메일",
+                style: TextStyle(
+                  color: Color(0xFF4C4C4C),
+                  fontSize: 16,
+                  fontFamily: 'NanumSquare_ac',
+                  fontWeight: FontWeight.w700,
+                  height: 0,
+                )),
+          ),
+          const SizedBox(
+            height: 25,
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              SizedBox(
+                  width: 250,
+                  height: 32,
+                  child: TextField(
+                    maxLines: 1,
+                    focusNode: emailFocusNode,
+                    obscureText: false,
+                    controller: emailController,
+                    decoration: const InputDecoration(
+                        focusedBorder: UnderlineInputBorder(
+                            borderSide: BorderSide(color: Color(0xFF640FAF))),
+                        isDense: true,
+                        hintText: "이메일 입력",
+                        contentPadding: EdgeInsets.all(10)),
+                  )),
+              SizedBox(
+                width: 80,
+                height: 42,
+                child: ElevatedButton(
+                  onPressed: getCode,
+                  style: ElevatedButton.styleFrom(
+                      elevation: 0,
+                      backgroundColor: const Color(0xFF640FAF),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(15),
+                      )),
+                  child: const Text(
+                    "인증요청",
+                    style: TextStyle(fontSize: 13, fontWeight: FontWeight.bold),
+                  ),
+                ),
+              )
+            ],
+          ),
+          const SizedBox(
+            height: 40,
+          ),
+          Container(
+            width: double.infinity,
+            height: 20,
+            margin: const EdgeInsets.only(top: 10, bottom: 25),
+            child: const Text("인증번호",
+                style: TextStyle(
+                  color: Color(0xFF4C4C4C),
+                  fontSize: 16,
+                  fontFamily: 'NanumSquare_ac',
+                  fontWeight: FontWeight.w700,
+                  height: 0,
+                )),
+          ),
+          SizedBox(
+            width: double.infinity,
+            height: 30,
+            child: TextField(
               maxLines: 1,
-              focusNode: emailFocusNode,
+              focusNode: codeFocusNode,
               obscureText: false,
-              controller: emailController,
+              controller: codeController,
               decoration: const InputDecoration(
                   focusedBorder: UnderlineInputBorder(
                       borderSide: BorderSide(color: Color(0xFF640FAF))),
                   isDense: true,
-                  hintText: "이메일 입력",
+                  hintText: "인증번호 입력",
                   contentPadding: EdgeInsets.all(10)),
             ),
-            TextButton(onPressed: getCode, child: const Text("인증 요청"))
-          ],
-        ),
-        const Text("인증번호"),
-        TextField(
-          maxLines: 1,
-          focusNode: emailFocusNode,
-          obscureText: false,
-          controller: emailController,
-          decoration: const InputDecoration(
-              focusedBorder: UnderlineInputBorder(
-                  borderSide: BorderSide(color: Color(0xFF640FAF))),
-              isDense: true,
-              hintText: "인증번호 입력",
-              contentPadding: EdgeInsets.all(10)),
-        ),
-      ],
+          )
+        ],
+      ),
     );
   }
 
   void getCode() {}
+
+  void moveChangePw() {}
 }

--- a/lib/View/login/screen/email_send_screen.dart
+++ b/lib/View/login/screen/email_send_screen.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:frontend/View/common/component/sub_app_bar.dart';
+
+class EmailSendScreen extends StatefulWidget {
+  const EmailSendScreen({super.key});
+
+  @override
+  State<StatefulWidget> createState() => _EmailSendScreen();
+}
+
+class _EmailSendScreen extends State<EmailSendScreen> {
+  FocusNode emailFocusNode = FocusNode();
+  FocusNode pwFocusNode = FocusNode();
+
+  TextEditingController emailController = TextEditingController();
+  TextEditingController codeController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: const SubAppBar(titleText: "비밀번호 재설정"), body: renderBody());
+  }
+
+  Widget renderBody() {
+    return Column(
+      children: [
+        const Text("이메일"),
+        Row(
+          children: [
+            TextField(
+              maxLines: 1,
+              focusNode: emailFocusNode,
+              obscureText: false,
+              controller: emailController,
+              decoration: const InputDecoration(
+                  focusedBorder: UnderlineInputBorder(
+                      borderSide: BorderSide(color: Color(0xFF640FAF))),
+                  isDense: true,
+                  hintText: "이메일 입력",
+                  contentPadding: EdgeInsets.all(10)),
+            ),
+            TextButton(onPressed: getCode, child: const Text("인증 요청"))
+          ],
+        ),
+        const Text("인증번호"),
+        TextField(
+          maxLines: 1,
+          focusNode: emailFocusNode,
+          obscureText: false,
+          controller: emailController,
+          decoration: const InputDecoration(
+              focusedBorder: UnderlineInputBorder(
+                  borderSide: BorderSide(color: Color(0xFF640FAF))),
+              isDense: true,
+              hintText: "인증번호 입력",
+              contentPadding: EdgeInsets.all(10)),
+        ),
+      ],
+    );
+  }
+
+  void getCode() {}
+}

--- a/lib/View/login/screen/email_send_screen.dart
+++ b/lib/View/login/screen/email_send_screen.dart
@@ -89,7 +89,7 @@ class _EmailSendScreen extends State<EmailSendScreen> {
                     maxLines: 1,
                     focusNode: emailFocusNode,
                     obscureText: false,
-                    readOnly: emailEdit,
+                    enabled: !emailEdit,
                     controller: emailController,
                     decoration: const InputDecoration(
                         focusedBorder: UnderlineInputBorder(
@@ -199,7 +199,11 @@ class _EmailSendScreen extends State<EmailSendScreen> {
     Future<dynamic> result = LoginService().requestEmail(email);
     result.then((value) => {
           if (value == true)
-            {setState(() {})}
+            {
+              setState(() {
+                emailEdit = true;
+              })
+            }
           else if (value == false)
             {showAlert("알 수 없는 오류가 발생했습니다. 다시 시도해주세요.")}
           else

--- a/lib/View/login/screen/email_send_screen.dart
+++ b/lib/View/login/screen/email_send_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:frontend/Presenter/login/login_service.dart';
 import 'package:frontend/View/common/component/purple_bottom_button.dart';
 import 'package:frontend/View/common/component/sub_app_bar.dart';
 
@@ -143,7 +144,68 @@ class _EmailSendScreen extends State<EmailSendScreen> {
     );
   }
 
-  void getCode() {}
+  void showAlert(String content) {
+    showDialog(
+        context: context,
+        barrierDismissible: false,
+        builder: (BuildContext context) {
+          return AlertDialog(
+            shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(10.0)),
+            title: const Column(
+              children: <Widget>[
+                Text("이메일 인증 요청 오류"),
+              ],
+            ),
+            //
+            content: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(content),
+              ],
+            ),
+            actions: <Widget>[
+              TextButton(
+                child: const Text(
+                  "확인",
+                  style: TextStyle(
+                    color: Colors.red,
+                    fontSize: 16,
+                    decoration: TextDecoration.underline,
+                  ),
+                ),
+                onPressed: () {
+                  Navigator.pop(context);
+                },
+              ),
+            ],
+          );
+        });
+  }
 
-  void moveChangePw() {}
+  void getCode() {
+    var email = emailController.text;
+    Future<dynamic> result = LoginService().requestEmail(email);
+    result.then((value) => {
+          if (value == false)
+            {showAlert("알 수 없는 오류가 발생했습니다. 다시 시도해주세요.")}
+          else
+            {showAlert(value)}
+        });
+  }
+
+  void moveChangePw() {
+    var email = emailController.text;
+    var code = codeController.text;
+    Future<dynamic> result = LoginService().requestEmailCode(email, code);
+    result.then((value) => {
+          if (value == true)
+            {showAlert("성공")}
+          else if (value == false)
+            {showAlert("알 수 없는 오류가 발생했습니다. 다시 시도해주세요.")}
+          else
+            {showAlert(value)}
+        });
+  }
 }

--- a/lib/View/login/screen/login_screen.dart
+++ b/lib/View/login/screen/login_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:frontend/Presenter/login/login_service.dart';
+import 'package:frontend/View/login/screen/email_send_screen.dart';
 
 import '../../common/screen/root_tab.dart';
 
@@ -232,6 +233,7 @@ class _LoginScreenState extends State<LoginScreen> {
   }
 
   void findPw() {
-    print("find pw");
+    Navigator.of(context)
+        .push(MaterialPageRoute(builder: (_) => const EmailSendScreen()));
   }
 }

--- a/lib/View/login/screen/password_screen.dart
+++ b/lib/View/login/screen/password_screen.dart
@@ -1,0 +1,189 @@
+import 'package:flutter/material.dart';
+import 'package:frontend/Presenter/login/login_service.dart';
+import 'package:frontend/View/common/component/purple_bottom_button.dart';
+import 'package:frontend/View/common/component/sub_app_bar.dart';
+import 'package:frontend/View/login/screen/login_screen.dart';
+
+class PasswordScreen extends StatefulWidget {
+  final String email;
+  const PasswordScreen({Key? key, required this.email}) : super(key: key);
+
+  @override
+  State<StatefulWidget> createState() => _EmailSendScreen();
+}
+
+class _EmailSendScreen extends State<PasswordScreen> {
+  FocusNode passwordFocusNode = FocusNode();
+  FocusNode checkPasswordFocusNode = FocusNode();
+
+  TextEditingController passwordController = TextEditingController();
+  TextEditingController checkPasswordController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    passwordFocusNode.dispose();
+    checkPasswordFocusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+        onTap: () {
+          passwordFocusNode.unfocus();
+          checkPasswordFocusNode.unfocus();
+        },
+        child: Scaffold(
+          resizeToAvoidBottomInset: false,
+          appBar: const SubAppBar(titleText: "비밀번호 재설정"),
+          body: renderBody(),
+          backgroundColor: Colors.white,
+          bottomNavigationBar: PurpleBottomButton(
+            title: "확인",
+            onPressed: changePw,
+          ),
+        ));
+  }
+
+  Widget renderBody() {
+    return Container(
+      width: double.infinity,
+      height: double.infinity,
+      margin: const EdgeInsets.only(top: 70, left: 21, right: 19),
+      child: Column(
+        children: [
+          const SizedBox(
+            width: double.infinity,
+            height: 20,
+            child: Text("새 비밀번호",
+                style: TextStyle(
+                  color: Color(0xFF4C4C4C),
+                  fontSize: 16,
+                  fontFamily: 'NanumSquare_ac',
+                  fontWeight: FontWeight.w700,
+                  height: 0,
+                )),
+          ),
+          const SizedBox(
+            height: 25,
+          ),
+          SizedBox(
+              width: double.infinity,
+              height: 32,
+              child: TextField(
+                maxLines: 1,
+                focusNode: passwordFocusNode,
+                obscureText: true,
+                controller: passwordController,
+                decoration: const InputDecoration(
+                    focusedBorder: UnderlineInputBorder(
+                        borderSide: BorderSide(color: Color(0xFF640FAF))),
+                    isDense: true,
+                    hintText: "새 비밀번호 입력",
+                    contentPadding: EdgeInsets.all(10)),
+              )),
+          const SizedBox(
+            height: 40,
+          ),
+          Container(
+            width: double.infinity,
+            height: 20,
+            margin: const EdgeInsets.only(top: 10, bottom: 25),
+            child: const Text("비밀번호 확인",
+                style: TextStyle(
+                  color: Color(0xFF4C4C4C),
+                  fontSize: 16,
+                  fontFamily: 'NanumSquare_ac',
+                  fontWeight: FontWeight.w700,
+                  height: 0,
+                )),
+          ),
+          SizedBox(
+            width: double.infinity,
+            height: 30,
+            child: TextField(
+              maxLines: 1,
+              focusNode: checkPasswordFocusNode,
+              obscureText: true,
+              controller: checkPasswordController,
+              decoration: const InputDecoration(
+                  focusedBorder: UnderlineInputBorder(
+                      borderSide: BorderSide(color: Color(0xFF640FAF))),
+                  isDense: true,
+                  hintText: "새 비밀번호 재입력",
+                  contentPadding: EdgeInsets.all(10)),
+            ),
+          )
+        ],
+      ),
+    );
+  }
+
+  void showAlert(String content) {
+    showDialog(
+        context: context,
+        barrierDismissible: false,
+        builder: (BuildContext context) {
+          return AlertDialog(
+            shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(10.0)),
+            title: const Column(
+              children: <Widget>[
+                Text("비밀번호 재설정 오류"),
+              ],
+            ),
+            //
+            content: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(content),
+              ],
+            ),
+            actions: <Widget>[
+              TextButton(
+                child: const Text(
+                  "확인",
+                  style: TextStyle(
+                    color: Colors.red,
+                    fontSize: 16,
+                    decoration: TextDecoration.underline,
+                  ),
+                ),
+                onPressed: () {
+                  Navigator.pop(context);
+                },
+              ),
+            ],
+          );
+        });
+  }
+
+  void changePw() {
+    var password = passwordController.text;
+    var checkPassword = checkPasswordController.text;
+    if (password == checkPassword) {
+      Future<dynamic> result =
+          LoginService().changePassword(widget.email, password);
+      result.then((value) => {
+            if (value == true)
+              {
+                Navigator.of(context).pushAndRemoveUntil(
+                    MaterialPageRoute(builder: (_) => const LoginScreen()),
+                    (route) => false)
+              }
+            else if (value == false)
+              {showAlert("알 수 없는 오류가 발생했습니다. 다시 시도해주세요.")}
+            else
+              {showAlert(value)}
+          });
+    } else {
+      showAlert("비밀번호와 재입력 비밀번호가 다릅니다. 다시 시도해주세요.");
+    }
+  }
+}

--- a/lib/View/mypage/screen/mypage_screen.dart
+++ b/lib/View/mypage/screen/mypage_screen.dart
@@ -38,6 +38,7 @@ class _MypageScreen extends State<MypageScreen> {
         builder: (context, snapshot) {
           if (snapshot.hasError) {
             data = ProfileResponse(name: "이름", role: "역할");
+            return mypageBody(data);
           }
 
           if (snapshot.hasData) {


### PR DESCRIPTION
## ✈️ 지라 티켓
- [PDA-19](https://pladi-alm.atlassian.net/browse/PDA-19) 

<br>

## 👾 작업 내용
- 이메일 인증 UI 구현
- 이메일 인증 API 연결
- 비밀번호 재설정 UI 구현
- 비밀번호 재설정 API연결

<br>


## 📸 스크린샷
<p>
<image/ src="https://github.com/PLADI-ALM/PLADI-ALM-Mobile/assets/81149634/fd035ce0-20ef-43dd-bc30-5460de22e198" width="45%">
<image/ src="https://github.com/PLADI-ALM/PLADI-ALM-Mobile/assets/81149634/de7007a4-c0f6-4939-809b-245793eddd27" width="45%">
</p>

<br>

## 🎸 기타 사항
- 


[PDA-19]: https://pladi-alm.atlassian.net/browse/PDA-19?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ